### PR TITLE
Update channel vectors to contain pointers of users

### DIFF
--- a/includes/channel.hpp
+++ b/includes/channel.hpp
@@ -28,12 +28,12 @@ private:
 	bool	isKeyEnabled;        //k
 	bool	isUserCountLimited;  //l
 
-	vector<user> users;
-	vector<user> operators;
-	vector<user> invitedUsers;
-	vector<user> voicedUsers;
+	vector<const user *> users;
+	vector<const user *> operators;
+	vector<const user *> invitedUsers;
+	vector<const user *> voicedUsers;
 
-	size_t	findUser(const vector<user> &userList, const user &User) const;
+	size_t	findUser(const vector<const user *> &userList, const user &User) const;
 
 public:
 	channel();
@@ -59,10 +59,10 @@ public:
 
 	string	getChannelModes() const;
 
-	const vector<user>	getUsers() const;
-	const vector<user>	getOperators() const;
-	const vector<user>	getInvitedUsers() const;
-	const vector<user>	getVoicedUsers() const;
+	const vector<const user *>	getUsers() const;
+	const vector<const user *>	getOperators() const;
+	const vector<const user *>	getInvitedUsers() const;
+	const vector<const user *>	getVoicedUsers() const;
 
 	/* setters */
 	void	setName(string name);
@@ -81,21 +81,21 @@ public:
 	void	setKeyEnabled(bool mode);
 	void	setUserCountLimited(bool mode);
 
-	void	addUser(user const &User);
-	void	removeUser(user const &User);
-	bool	isUser(user const &User) const;
+	void	addUser(const user &User);
+	void	removeUser(const user &User);
+	bool	isUser(const user &User) const;
 
-	void	addOperator(user const &Op);
-	void	removeOperator(user const &Op);
-	bool	isOperator(user const &Op) const;
+	void	addOperator(const user &Op);
+	void	removeOperator(const user &Op);
+	bool	isOperator(const user &Op) const;
 	
-	void	addVoicedUser(user const &User);
-	void	removeVoicedUser(user const &User);
-	bool	isVoicedUser(user const &User) const;
+	void	addVoicedUser(const user &User);
+	void	removeVoicedUser(const user &User);
+	bool	isVoicedUser(const user &User) const;
 	
-	void	addInvitedUser(user const &User);
-	void	removeInvitedUser(user const &User);
-	bool	isInvitedUser(user const &User) const;
+	void	addInvitedUser(const user &User);
+	void	removeInvitedUser(const user &User);
+	bool	isInvitedUser(const user &User) const;
 };
 
 #endif 

--- a/srcs/channel.cpp
+++ b/srcs/channel.cpp
@@ -17,11 +17,11 @@ isKeyEnabled(false), isUserCountLimited(false)
 {
 }
 /* helper function */
-size_t	channel::findUser(const vector<user> &userList, const user &User) const{
+size_t	channel::findUser(const vector<const user *> &userList, const user &User) const{
 	size_t	index = 0;
-	for (vector<user>::const_iterator it = userList.begin(); it != userList.end(); it++, index++)
+	for (vector<const user *>::const_iterator it = userList.begin(); it != userList.end(); it++, index++)
 	{
-		if (it->getNickname() == User.getNickname())
+		if ((*it)->getNickname() == User.getNickname())
 			return index;
 	}
 	return -1;
@@ -103,19 +103,19 @@ string	channel::getChannelModes() const{
 }
 
 /* vectors */
-const vector<user>	channel::getUsers() const{
+const vector<const user *>	channel::getUsers() const{
 	return users;
 }
 
-const vector<user>	channel::getOperators() const{
+const vector<const user *>	channel::getOperators() const{
 	return operators;
 }
 
-const vector<user>	channel::getInvitedUsers() const{
+const vector<const user *>	channel::getInvitedUsers() const{
 	return invitedUsers;
 }
 
-const vector<user>	channel::getVoicedUsers() const{
+const vector<const user *>	channel::getVoicedUsers() const{
 	return voicedUsers;
 }
 
@@ -171,12 +171,12 @@ void	channel::setUserCountLimited(bool mode){
 
 /* vectors */
 void	channel::addUser(user const &User){
-	users.push_back(User);
+	users.push_back(&User);
 	if (users.size() == 1)    //make the first the channel user an operator 
 		addOperator(User);
 }
 
-void	channel::removeUser(user const &User){
+void	channel::removeUser(const user &User){
 	users.erase(users.begin() + findUser(users, User));
 	if (isOperator(User))
 		removeOperator(User);
@@ -186,51 +186,51 @@ void	channel::removeUser(user const &User){
 		removeVoicedUser(User);
 }
 
-bool	channel::isUser(user const &User) const{
+bool	channel::isUser(const user &User) const{
 	if (users.empty() || findUser(users, User) == MAX_SIZE_T)
 		return false;
 	return true;
 }
 
 
-void	channel::addOperator(user const &Op){
-	operators.push_back(Op);
+void	channel::addOperator(const user &Op){
+	operators.push_back(&Op);
 }
 
-void	channel::removeOperator(user const &Op){
+void	channel::removeOperator(const user &Op){
 	operators.erase(operators.begin() + findUser(operators, Op));
 }
 
-bool	channel::isOperator(user const &Op) const{
+bool	channel::isOperator(const user &Op) const{
 	if (operators.empty() || findUser(operators, Op) == MAX_SIZE_T)
 		return false;
 	return true;
 }
 
-void	channel::addVoicedUser(user const &User){
-	voicedUsers.push_back(User);
+void	channel::addVoicedUser(const user &User){
+	voicedUsers.push_back(&User);
 }
 
-void	channel::removeVoicedUser(user const &User){
+void	channel::removeVoicedUser(const user &User){
 	voicedUsers.erase(voicedUsers.begin() + findUser(voicedUsers, User));
 }
 
-bool	channel::isVoicedUser(user const &User) const{
+bool	channel::isVoicedUser(const user &User) const{
 	if (voicedUsers.empty() || findUser(voicedUsers, User) == MAX_SIZE_T)
 		return false;
 	return true;
 
 }
 
-void	channel::addInvitedUser(user const &User){
-	invitedUsers.push_back(User);
+void	channel::addInvitedUser(const user &User){
+	invitedUsers.push_back(&User);
 }
 
-void	channel::removeInvitedUser(user const &User){
+void	channel::removeInvitedUser(const user &User){
 	invitedUsers.erase(invitedUsers.begin() + findUser(invitedUsers, User));
 }
 
-bool	channel::isInvitedUser(user const &User) const{
+bool	channel::isInvitedUser(const user &User) const{
 	if (invitedUsers.empty() || findUser(invitedUsers, User) == MAX_SIZE_T)
 		return false;
 	return true;

--- a/srcs/reply.cpp
+++ b/srcs/reply.cpp
@@ -4,15 +4,15 @@ reply::reply(): userFds(), msg("") {}
 	
 void	reply::setUserFds(const channel& c){
 	for (size_t i = 0; i < c.getUsers().size(); i++) {
-		this->userFds.push_back(c.getUsers()[i].getFd());
+		this->userFds.push_back(c.getUsers()[i]->getFd());
 	}
 }
 
 void	reply::setUserFds(const channel& c, int fd){
 	for (size_t i = 0; i < c.getUsers().size(); i++) {
 
-		if (c.getUsers()[i].getFd() != fd)
-			this->userFds.push_back(c.getUsers()[i].getFd());
+		if (c.getUsers()[i]->getFd() != fd)
+			this->userFds.push_back(c.getUsers()[i]->getFd());
 	}
 }
 


### PR DESCRIPTION
To make changes in user info reflect in the vector lists present in each channel object, I turned the vectors from `vector<user>` to `vector<const user *>`. The former would take copies of the user, while the latter would store a pointer to the original user.

Resolves #12 